### PR TITLE
filter out missing classpath entries

### DIFF
--- a/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
@@ -34,7 +34,7 @@ private object Osgi {
     embeddedJars: Seq[File],
     streams: TaskStreams): File = {
     val builder = new Builder
-    builder.setClasspath(fullClasspath map (_.data) toArray)
+    builder.setClasspath(fullClasspath map (_.data) filter (_.exists) toArray)
     builder.setProperties(headersToProperties(headers, additionalHeaders))
     includeResourceProperty(resourceDirectories.filter(_.exists), embeddedJars) foreach (dirs =>
       builder.setProperty(INCLUDERESOURCE, dirs)


### PR DESCRIPTION
Bnd issues an error when a classpath entry does not exist (which will be the case with project dependencies that do not produce class files). Filtering out nonexistent classpath entries fixes this.
