### PR TITLE
Migrate from sbt.Plugin => sbt.AutoPlugin for automatic and safe injection of settings / plugin dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,47 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.8.0-SNAPSHOT")
 Using sbt-osgi
 ---------------
 
+#### Version 0.8.0 and above
+As, since version `0.8.0`, sbt-osgi uses the sbt 0.13.5 *Autoplugin* feature, it can be enabled for individual projects like any other sbt Autoplugin. For more information on enabling and disabling plugins, refer to the [sbt plugins tutorial](http://www.scala-sbt.org/release/tutorial/Using-Plugins.html#Enabling+and+disabling+auto+plugins).
+
+To enable sbt-osgi for a specific Project, use the project instance `enablePlugins(Plugins*)` method providing it with `SbtOsgi` as a parameter value. If using only '*.sbt' definition files with only the implicitly declared root project you will be required to obtain a reference to the project by explicitly declaring it in your build file. This may easily be done using the `project` macro, as shown in the example below.
+
+Example `<PROJECT_ROOT>/build.sbt`:
+
+```scala
+lazy val fooProject = (project in file(".")) // Obtain the root project reference
+  .enablePlugins(SbtOsgi)  // Enables sbt-osgi for this project. This will automatically append
+                           // the plugin's default settings to this project thus providing the
+                           // `osgiBundle` task.
+```
+
+Example `<PROJECT_ROOT>/project/Build.scala`:
+```scala
+import sbt._
+import com.typesafe.sbt.SbtOsgi.autoImport._  // The autoImport object contains everything which would normally be
+                                              // imported automatically in '*.sbt' project definition files.
+
+object Build extends sbt.Build {
+
+  lazy val fooProject = Project("foo-project", file("."))
+    .enablePlugins(SbtOsgi)  // Enables sbt-osgi for this project. This will automatically append
+                             // the plugin's default settings to this project thus providing the
+                             // `osgiBundle` task.
+}
+
+```
+
+To also override the default publish behaviour, also add the `osgiSettings` settings to your project via your preferred method.
+
+Example `<PROJECT_ROOT>/build.sbt`:
+
+```scala
+// Other settings
+
+osgiSettings
+```
+
+#### Version 0.7.0 and below
 Add the below line to your sbt build definition, which adds the task `osgiBundle` which creates an OSGi bundle for your project and also changes the `publish` task to publish an OSGi bundle instead of a raw JAR archive. Again, pay attention to the blank line between settings:
 
 ```

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/main/scala/com/typesafe/sbt/osgi/OsgiKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/OsgiKeys.scala
@@ -23,43 +23,43 @@ object OsgiKeys {
 
   val bundle: TaskKey[File] =
     TaskKey[File](
-      prefix("bundle"),
+      prefix("Bundle"),
       "Create an OSGi bundle."
     )
 
   val manifestHeaders: SettingKey[OsgiManifestHeaders] =
     SettingKey[OsgiManifestHeaders](
-      prefix("manifest-headers"),
+      prefix("ManifestHeaders"),
       "The aggregated manifest headers."
     )
 
   val bundleActivator: SettingKey[Option[String]] =
     SettingKey[Option[String]](
-      prefix("bundle-activator"),
+      prefix("BundleActivator"),
       "Optional value for *Bundle-Activator* header."
     )
 
   val bundleSymbolicName: SettingKey[String] =
     SettingKey[String](
-      prefix("bundle-symbolic-name"),
+      prefix("BundleSymbolicName"),
       "Value for *Bundle-SymbolicName* header."
     )
 
   val bundleVersion: SettingKey[String] =
     SettingKey[String](
-      prefix("bundle-version"),
+      prefix("BundleVersion"),
       "Value for *Bundle-Version* header."
     )
 
   val dynamicImportPackage: SettingKey[Seq[String]] =
     SettingKey[Seq[String]](
-      prefix("dynamic-import-package"),
+      prefix("DynamicImportPackage"),
       "Values for *Dynamic-ImportPackage* header."
     )
 
   val exportPackage: SettingKey[Seq[String]] =
     SettingKey[Seq[String]](
-      prefix("export-package"),
+      prefix("ExportPackage"),
       "Values for *Export-Package* header."
     )
 
@@ -71,33 +71,33 @@ object OsgiKeys {
 
   val fragmentHost: SettingKey[Option[String]] =
     SettingKey[Option[String]](
-      prefix("fragment-host"),
+      prefix("FragmentHost"),
       "Optional value for *Fragment-Host* header."
     )
 
   val privatePackage: SettingKey[Seq[String]] =
     SettingKey[Seq[String]](
-      prefix("private-package"),
+      prefix("PrivatePackage"),
       "Values for *Private-Package* header."
     )
 
   val requireBundle: SettingKey[Seq[String]] =
     SettingKey[Seq[String]](
-      prefix("require-bundle"),
+      prefix("RequireBundle"),
       "Values for *Require-Bundle* header."
     )
 
   val additionalHeaders: SettingKey[Map[String, String]] =
     SettingKey[Map[String, String]](
-      prefix("additional-headers"),
+      prefix("AdditionalHeaders"),
       "Additional headers to pass to BND."
     )
 
   val embeddedJars: TaskKey[Seq[File]] =
     TaskKey[Seq[File]](
-      prefix("embedded-jars"),
+      prefix("EmbeddedJars"),
       "Jar files to be embedded inside the bundle."
     )
 
-  private def prefix(key: String) = "osgi-" + key
+  private def prefix(key: String) = "osgi" + key
 }

--- a/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
@@ -18,17 +18,26 @@ package com.typesafe.sbt.osgi
 
 import sbt._
 import sbt.Keys._
+import sbt.plugins.JvmPlugin
 
-object SbtOsgi extends Plugin {
+object SbtOsgi extends AutoPlugin {
 
-  type OsgiManifestHeaders = com.typesafe.sbt.osgi.OsgiManifestHeaders
+  override val trigger: PluginTrigger = noTrigger
 
-  val OsgiKeys = com.typesafe.sbt.osgi.OsgiKeys
+  override val requires: Plugins = JvmPlugin
 
-  def osgiSettings: Seq[Setting[_]] = defaultOsgiSettings ++ Seq(
-    packagedArtifact in (Compile, packageBin) <<= (artifact in (Compile, packageBin), OsgiKeys.bundle).identityMap,
-    artifact in (Compile, packageBin) ~= (_.copy(`type` = "bundle"))
-  )
+  override lazy val projectSettings: Seq[Def.Setting[_]] = defaultOsgiSettings
+
+  object autoImport {
+    type OsgiManifestHeaders = com.typesafe.sbt.osgi.OsgiManifestHeaders
+
+    val OsgiKeys = com.typesafe.sbt.osgi.OsgiKeys
+
+    def osgiSettings: Seq[Setting[_]] = Seq(
+      packagedArtifact in (Compile, packageBin) <<= (artifact in (Compile, packageBin), OsgiKeys.bundle).identityMap,
+      artifact in (Compile, packageBin) ~= (_.copy(`type` = "bundle"))
+    )
+  }
 
   def defaultOsgiSettings: Seq[Setting[_]] = {
     import OsgiKeys._


### PR DESCRIPTION
We have been making heavy use of internal sbt-plugins for uniform configuration of builds, and migrating to sbt 0.13.5 have found the new Autoplugin [plugin dependencies](http://www.scala-sbt.org/release/docs/Plugins.html#Plugin+dependencies) feature very useful for this purpose; allowing one to specify a requirement on a plugin as well as its requirements, and having all necessary settings provided to specific projects.

This change updates SbtOsgi to extend [sbt.AutoPlugin](http://www.scala-sbt.org/0.13.5/api/#sbt.AutoPlugin) instead of [sbt.Plugin](http://www.scala-sbt.org/0.13.5/api/#sbt.Plugin) (similar to sbt-web, play etc.).  
-  `SbtOsgi.defaultOsgiSettings` are now provided automatically to all projects which explicitly enable `SbtOsgi` via the `enablePlugins(Plugins*)` method.
-  `osgiSettings` and the `OsgiKeys` alias have been moved from `SbtOsgi` to `SbtOsgi.autoImport` as only members of an object named `autoImport` are automatically imported into scope in '*.sbt' files, unlike the behaviour of `sbt.Plugin`
- TaskKey and SettingKey ids have been updated to match the current convention of lowerCamelCase instead of hyphen-separated-lowercase.
-  README updated to match usage changes.

Usage changes as follows:
Plugin is enabled, and `defaultOsgiSettings` appended to a project settings when `enablePlugins(SbtOsgi)` is called on the project; so appending `defaultOsgiSettings` to project settings is replaced by the call to `enablePlugins(SbtOsgi)`. eg. :

``` scala
lazy val fooProject = (project in file(".")) 
  .enablePlugins(SbtOsgi)  // Enables sbt-osgi for this project. This will automatically append
                           // the plugin's default settings to this project thus providing the
                           // `osgiBundle` task.

osgiSettings  // Override the default publish behaviour

```
