### PR TITLE
add the scala version to the bundle symbolic name

### DIFF
--- a/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
@@ -95,14 +95,14 @@ private object Osgi {
   def bundleClasspathProperty(embeddedJars: Seq[File]) =
     seqToStrOpt(embeddedJars)(_.getName) map (".," + _)
 
-  def defaultBundleSymbolicName(organization: String, name: String): String = {
+  def defaultBundleSymbolicName(organization: String, name: String, scalaVersion: String): String = {
     val organizationParts = parts(organization)
     val nameParts = parts(name)
     val partsWithoutOverlap = (organizationParts.lastOption, nameParts.headOption) match {
       case (Some(last), Some(head)) if (last == head) => organizationParts ++ nameParts.tail
       case _ => organizationParts ++ nameParts
     }
-    partsWithoutOverlap mkString "."
+    (partsWithoutOverlap mkString ".") + "_" + scalaVersion
   }
 
   def id(s: String) = s

--- a/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
@@ -70,7 +70,7 @@ object SbtOsgi extends AutoPlugin {
         requireBundle.value
       ),
       bundleActivator := None,
-      bundleSymbolicName <<= (organization, normalizedName)(Osgi.defaultBundleSymbolicName),
+      bundleSymbolicName <<= (organization, normalizedName, scalaBinaryVersion)(Osgi.defaultBundleSymbolicName),
       bundleVersion <<= version,
       bundleRequiredExecutionEnvironment := Nil,
       dynamicImportPackage := Nil,

--- a/src/test/scala/com/typesafe/sbt/osgi/OsgiSpec.scala
+++ b/src/test/scala/com/typesafe/sbt/osgi/OsgiSpec.scala
@@ -79,14 +79,15 @@ class OsgiSpec extends Specification {
 
   "Calling defaultBundleSymbolicName" should {
     "concatenate organization and name properly" in {
-      defaultBundleSymbolicName("a.b.c", "d.c") must beEqualTo("a.b.c.d.c")
-      defaultBundleSymbolicName("a.b.c", "d-c") must beEqualTo("a.b.c.d.c")
-      defaultBundleSymbolicName("a.b.c", "c.d") must beEqualTo("a.b.c.d")
-      defaultBundleSymbolicName("a.b.c", "c-d") must beEqualTo("a.b.c.d")
-      defaultBundleSymbolicName("", "a") must beEqualTo("a")
-      defaultBundleSymbolicName("a", "") must beEqualTo("a")
-      defaultBundleSymbolicName("", "") must beEqualTo("")
+      defaultBundleSymbolicName("a.b.c", "d.c", "2.10") must beEqualTo("a.b.c.d.c_2.10")
+      defaultBundleSymbolicName("a.b.c", "d-c", "2.10") must beEqualTo("a.b.c.d.c_2.10")
+      defaultBundleSymbolicName("a.b.c", "c.d", "2.10") must beEqualTo("a.b.c.d_2.10")
+      defaultBundleSymbolicName("a.b.c", "c-d", "2.10") must beEqualTo("a.b.c.d_2.10")
+      defaultBundleSymbolicName("", "a", "2.10") must beEqualTo("a_2.10")
+      defaultBundleSymbolicName("a", "", "2.10") must beEqualTo("a_2.10")
+      defaultBundleSymbolicName("", "", "2.10") must beEqualTo("_2.10")
     }
+
   }
 
   "Calling includeResourceProperty" should {


### PR DESCRIPTION
To manage  several versions of Scala in an OSGi, this is easier to see
immediately on which binary version a bundle depends.
