### PR TITLE
Upgrade bndlib to 2.4. Override wrong Require-Capability generated by bnd 2.3+ for Scala classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Using sbt-osgi
 #### Version 0.8.0 and above
 As, since version `0.8.0`, sbt-osgi uses the sbt 0.13.5 *Autoplugin* feature, it can be enabled for individual projects like any other sbt Autoplugin. For more information on enabling and disabling plugins, refer to the [sbt plugins tutorial](http://www.scala-sbt.org/release/tutorial/Using-Plugins.html#Enabling+and+disabling+auto+plugins).
 
-To enable sbt-osgi for a specific Project, use the project instance `enablePlugins(Plugins*)` method providing it with `SbtOsgi` as a parameter value. If using only '*.sbt' definition files with only the implicitly declared root project with sbt 0.13.5 you will be required to obtain a reference to the project by explicitly declaring it in your build file. This may easily be done using the `project` macro, as shown in the example below. If using sbt 0.13.6 or greater, `enablePlugins(Plugins*)` is directly available in `*.sbt` files.
+To enable sbt-osgi for a specific Project, use the project instance `enablePlugins(Plugins*)` method providing it with `SbtOsgi` as a parameter value. If using only '.sbt' definition files with only the implicitly declared root project with sbt 0.13.5 you will be required to obtain a reference to the project by explicitly declaring it in your build file. This may easily be done using the `project` macro, as shown in the example below. If using sbt 0.13.6 or greater, `enablePlugins(Plugins*)` is directly available in `.sbt` files.
 
 Example `<PROJECT_ROOT>/build.sbt`:
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@ In order to add sbt-osgi as a plugin, just add the below setting to the relevant
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")
 ```
 
-If you want to use the latest and greates features, you can also give the latest snapshot release a try:
+If you want to use the latest and greatest features, you can instead have sbt depend on and locally build the current source snapshot by adding the following to your plugin definition file.
+Example `<PROJECT_ROOT>/project/plugins.sbt`:
+```scala
+lazy val plugins = (project in file("."))
+  .dependsOn(sbtOsgi)
 
-```
 // Other stuff
 
-resolvers += Classpaths.sbtPluginSnapshots
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.8.0-SNAPSHOT")
+def sbtOsgi = uri("git://github.com/sbt/sbt-osgi.git")
 ```
 
 Using sbt-osgi
@@ -37,15 +38,19 @@ Using sbt-osgi
 #### Version 0.8.0 and above
 As, since version `0.8.0`, sbt-osgi uses the sbt 0.13.5 *Autoplugin* feature, it can be enabled for individual projects like any other sbt Autoplugin. For more information on enabling and disabling plugins, refer to the [sbt plugins tutorial](http://www.scala-sbt.org/release/tutorial/Using-Plugins.html#Enabling+and+disabling+auto+plugins).
 
-To enable sbt-osgi for a specific Project, use the project instance `enablePlugins(Plugins*)` method providing it with `SbtOsgi` as a parameter value. If using only '*.sbt' definition files with only the implicitly declared root project you will be required to obtain a reference to the project by explicitly declaring it in your build file. This may easily be done using the `project` macro, as shown in the example below.
+To enable sbt-osgi for a specific Project, use the project instance `enablePlugins(Plugins*)` method providing it with `SbtOsgi` as a parameter value. If using only '*.sbt' definition files with only the implicitly declared root project with sbt 0.13.5 you will be required to obtain a reference to the project by explicitly declaring it in your build file. This may easily be done using the `project` macro, as shown in the example below. If using sbt 0.13.6 or greater, `enablePlugins(Plugins*)` is directly available in `*.sbt` files.
 
 Example `<PROJECT_ROOT>/build.sbt`:
 
 ```scala
+// sbt 0.13.5
 lazy val fooProject = (project in file(".")) // Obtain the root project reference
   .enablePlugins(SbtOsgi)  // Enables sbt-osgi for this project. This will automatically append
                            // the plugin's default settings to this project thus providing the
                            // `osgiBundle` task.
+
+// sbt 0.13.6+
+enablePlugins(SbtOsgi) // No need to obtain root project reference on single project builds for sbt 0.13.6+
 ```
 
 Example `<PROJECT_ROOT>/project/Build.scala`:
@@ -98,6 +103,7 @@ Settings
 sbt-osgi can be configured with the following settings:
 
 - `bundleActivator`: value for `Bundle-Activator` header, default is `None`
+- `bundleRequiredExecutionEnvironment`: value for `Bundle-RequiredExecutionEnvironment` header, default is an empty string.
 - `bundleSymbolicName`: value for `Bundle-SymbolicName` header, default is `organization` plus `name`
 - `bundleVersion`: value for `Bundle-Version` header, default is `version`
 - `dynamicImportPackage`: values for `Dynamic-ImportPackage` header, default is the empty sequence
@@ -109,6 +115,7 @@ sbt-osgi can be configured with the following settings:
 - `additionalHeaders`: map of additional headers to be passed to BND, default is the empty sequence
 - `embeddedJars`: list of dependencies to embed inside the bundle which are automatically added to `Bundle-Classpath`
 - `explodedJars`: list of jarfiles to explode into the bundle
+- `requireCapability`: value for `Require-Capability` header, defaults to `osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=*PROJECT JAVAC VERSION*))"`
 
 Example `build.sbt`:
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Library {
 
   // Versions
-  val bndVersion = "2.1.0"
+  val bndVersion = "2.4.0"
   val specs2Version = "1.14"
 
   // Libraries

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
-sbt.version=0.13.5
+sbt.version=0.13.7
+

--- a/src/main/scala/com/typesafe/sbt/osgi/OsgiKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/OsgiKeys.scala
@@ -17,7 +17,6 @@
 package com.typesafe.sbt.osgi
 
 import sbt._
-import sbt.Keys._
 
 object OsgiKeys {
 
@@ -27,8 +26,8 @@ object OsgiKeys {
       "Create an OSGi bundle."
     )
 
-  val manifestHeaders: SettingKey[OsgiManifestHeaders] =
-    SettingKey[OsgiManifestHeaders](
+  val manifestHeaders: TaskKey[OsgiManifestHeaders] =
+    TaskKey[OsgiManifestHeaders](
       prefix("ManifestHeaders"),
       "The aggregated manifest headers."
     )
@@ -110,6 +109,10 @@ object OsgiKeys {
       prefix("ExplodedJars"),
       "Jar files to be exploded into the bundle."
     )
+
+  val requireCapability: TaskKey[String] =
+    TaskKey[String](prefix("RequireCapability"), "Value for *Require-Capability* header. If not" +
+      "specified defaults to 'osgi.ee;filter:=\"(&(osgi.ee=JavaSE)(version=*PROJECT JAVA VERSION*))\"'.")
 
   private def prefix(key: String) = "osgi" + key
 

--- a/src/main/scala/com/typesafe/sbt/osgi/OsgiManifestHeaders.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/OsgiManifestHeaders.scala
@@ -33,4 +33,5 @@ case class OsgiManifestHeaders(
   importPackage: Seq[String],
   fragmentHost: Option[String],
   privatePackage: Seq[String],
-  requireBundle: Seq[String])
+  requireBundle: Seq[String],
+  requireCapability: String)

--- a/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
@@ -67,7 +67,8 @@ object SbtOsgi extends AutoPlugin {
         importPackage.value,
         fragmentHost.value,
         privatePackage.value,
-        requireBundle.value
+        requireBundle.value,
+        requireCapability.value
       ),
       bundleActivator := None,
       bundleSymbolicName <<= (organization, normalizedName)(Osgi.defaultBundleSymbolicName),
@@ -79,6 +80,9 @@ object SbtOsgi extends AutoPlugin {
       fragmentHost := None,
       privatePackage <<= bundleSymbolicName(name => List(name + ".*")),
       requireBundle := Nil,
+      requireCapability := Osgi.requireCapabilityTask(
+        (compileInputs in (Compile, compile)).value.compilers.javac,
+        streams.value.log),
       additionalHeaders := Map.empty,
       embeddedJars := Nil,
       explodedJars := Nil

--- a/src/test/scala/com/typesafe/sbt/osgi/OsgiSpec.scala
+++ b/src/test/scala/com/typesafe/sbt/osgi/OsgiSpec.scala
@@ -17,10 +17,8 @@
 package com.typesafe.sbt.osgi
 
 import aQute.bnd.osgi.Constants._
-import java.util.Properties
 import java.io.File
 import org.specs2.mutable.Specification
-import sbt.URL
 import scala.collection.JavaConverters._
 
 class OsgiSpec extends Specification {
@@ -54,7 +52,8 @@ class OsgiSpec extends Specification {
         Seq("importPackage"),
         None,
         Seq("privatePackage"),
-        Nil
+        Nil,
+        "requireCapability"
       )
       val properties = headersToProperties(headers, Map.empty)
       properties.asScala must havePairs(
@@ -70,7 +69,8 @@ class OsgiSpec extends Specification {
         DYNAMICIMPORT_PACKAGE -> "dynamicImportPackage",
         EXPORT_PACKAGE -> "exportPackage1,exportPackage2,exportPackage3",
         IMPORT_PACKAGE -> "importPackage",
-        PRIVATE_PACKAGE -> "privatePackage"
+        PRIVATE_PACKAGE -> "privatePackage",
+        REQUIRE_CAPABILITY → "requireCapability"
       )
       properties.asScala must not(haveKey(FRAGMENT_HOST))
       properties.asScala must not(haveKey(REQUIRE_BUNDLE))


### PR DESCRIPTION
bnd 2.3 and newer [automatically generates][1] a `Require-Capability` manifest header based on the java version obtained from the project compiled classes class version. This does not work as the class version of scalac generated classes does not coincide with the jdk version in use. (With Scala 2.11 projects the bnd generated value is `osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.6))"` regardless of actual jdk version used.)

This adds a requireCapability setting (TaskKey) which if not set defaults to `osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=*PROJECT JAVAC VERSION*))"` e.g. For a project compiled with Java 8, the generated header is `Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"`.

`osgiManifestHeaders` has also been changed to a TaskKey as a setting cannot depend on a task, and it depends on `requireCapability`, which must be a task since it depends on `(compileInputs in (Compile, compile))` to obtain the project's javac instance.

Sbt also updated from 0.13.5 -> 0.13.7.

[1]:  https://github.com/bndtools/bnd/issues/413