### PR TITLE
package task support for osgi bundles

### DIFF
--- a/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
@@ -29,14 +29,15 @@ private object Osgi {
   def bundleTask(
     headers: OsgiManifestHeaders,
     additionalHeaders: Map[String, String],
-    fullClasspath: Seq[Attributed[File]],
+    dependencyClasspath: Seq[Attributed[File]],
+    products: Seq[File],
     artifactPath: File,
     resourceDirectories: Seq[File],
     embeddedJars: Seq[File],
     explodedJars: Seq[File],
     streams: TaskStreams): File = {
     val builder = new Builder
-    builder.setClasspath(fullClasspath map (_.data) toArray)
+    builder.setClasspath((dependencyClasspath.files ++ products) toArray)
     builder.setProperties(headersToProperties(headers, additionalHeaders))
     includeResourceProperty(resourceDirectories.filter(_.exists), embeddedJars, explodedJars) foreach (dirs =>
       builder.setProperty(INCLUDERESOURCE, dirs)

--- a/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
@@ -34,7 +34,7 @@ object SbtOsgi extends AutoPlugin {
     val OsgiKeys = com.typesafe.sbt.osgi.OsgiKeys
 
     def osgiSettings: Seq[Setting[_]] = Seq(
-      packagedArtifact in (Compile, packageBin) <<= (artifact in (Compile, packageBin), OsgiKeys.bundle).identityMap,
+      packageBin in Compile <<= OsgiKeys.bundle,
       artifact in (Compile, packageBin) ~= (_.copy(`type` = "bundle"))
     )
   }
@@ -45,7 +45,8 @@ object SbtOsgi extends AutoPlugin {
       bundle <<= (
         manifestHeaders,
         additionalHeaders,
-        fullClasspath in Compile,
+        dependencyClasspath in Compile,
+        products in Compile,
         artifactPath in (Compile, packageBin),
         resourceDirectories in Compile,
         embeddedJars,


### PR DESCRIPTION
With this change it is possible to run `sbt package` instead of `sbt osgiBundle` to create the package. This is also necessary when the JAR's are required in other plugins (which usually depend on `package`).

This is achieved by splitting the `fullClasspath` (causing a circular dependency on `artifact` when used in combination with `package`) into `dependencyClasspath` and `products`. 