### PR TITLE
Fix deprecation warnings

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.13.7
+sbt.version=0.13.13
 

--- a/scripted.sbt
+++ b/scripted.sbt
@@ -3,6 +3,6 @@ scriptedSettings
 
 scriptedLaunchOpts += "-Xmx1024m"
 
-scriptedLaunchOpts <+= version apply { v => "-Dproject.version="+v }
+scriptedLaunchOpts += s"-Dproject.version=${version.value}"
 
 // scriptedBufferLog := false

--- a/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
@@ -34,7 +34,7 @@ object SbtOsgi extends AutoPlugin {
     val OsgiKeys = com.typesafe.sbt.osgi.OsgiKeys
 
     def osgiSettings: Seq[Setting[_]] = Seq(
-      packagedArtifact in (Compile, packageBin) <<= (artifact in (Compile, packageBin), OsgiKeys.bundle).identityMap,
+      packagedArtifact in (Compile, packageBin) := Scoped.mkTuple2((artifact in (Compile, packageBin)).value, OsgiKeys.bundle.value),
       artifact in (Compile, packageBin) ~= (_.copy(`type` = "bundle"))
     )
   }
@@ -72,14 +72,14 @@ object SbtOsgi extends AutoPlugin {
         requireCapability.value
       ),
       bundleActivator := None,
-      bundleSymbolicName <<= (organization, normalizedName)(Osgi.defaultBundleSymbolicName),
-      bundleVersion <<= version,
+      bundleSymbolicName := Osgi.defaultBundleSymbolicName(organization.value, normalizedName.value),
+      bundleVersion := version.value,
       bundleRequiredExecutionEnvironment := Nil,
       dynamicImportPackage := Nil,
       exportPackage := Nil,
       importPackage := List("*"),
       fragmentHost := None,
-      privatePackage <<= bundleSymbolicName(name => List(name + ".*")),
+      privatePackage := bundleSymbolicName(name => List(name + ".*")).value,
       requireBundle := Nil,
       failOnUndecidedPackage := false,
       requireCapability := Osgi.requireCapabilityTask(


### PR DESCRIPTION
This pull request fixes the following warnings.

```
[info] Compiling 4 Scala sources to /Users/kazuhirosera/github/oss/sbt-osgi/target/scala-2.10/sbt-0.13/classes...
[warn] /Users/kazuhirosera/github/oss/sbt-osgi/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala:37: `<<=` operator is deprecated. Use `key := { x.value }` or `key ~= (old => { newValue })`.
[warn] See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html
[warn]       packagedArtifact in (Compile, packageBin) <<= (artifact in (Compile, packageBin), OsgiKeys.bundle).identityMap,
[warn]                                                 ^
[warn] /Users/kazuhirosera/github/oss/sbt-osgi/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala:75: `<<=` operator is deprecated. Use `key := { x.value }` or `key ~= (old => { newValue })`.
[warn] See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html
[warn]       bundleSymbolicName <<= (organization, normalizedName)(Osgi.defaultBundleSymbolicName),
[warn]                          ^
[warn] /Users/kazuhirosera/github/oss/sbt-osgi/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala:76: `<<=` operator is deprecated. Use `key := { x.value }` or `key ~= (old => { newValue })`.
[warn] See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html
[warn]       bundleVersion <<= version,
[warn]                     ^
[warn] /Users/kazuhirosera/github/oss/sbt-osgi/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala:82: `<<=` operator is deprecated. Use `key := { x.value }` or `key ~= (old => { newValue })`.
[warn] See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html
[warn]       privatePackage <<= bundleSymbolicName(name => List(name + ".*")),
[warn]                      ^
[warn] /Users/kazuhirosera/github/oss/sbt-osgi/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala:123: trait JavaTool in package compiler is deprecated: Please use the new set of compilers in sbt.compilers.javac
[warn]   def requireCapabilityTask(compiler: JavaTool, logger: Logger): String = {
[warn]                                       ^
[warn] /Users/kazuhirosera/github/oss/sbt-osgi/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala:37: method t2ToTable2 in object Scoped is deprecated: The sbt 0.10 style DSL is deprecated: '(k1, k2) map { (x, y) => ... }' should now be '{ val x = k1.value; val y = k2.value }'.
[warn] See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html
[warn]       packagedArtifact in (Compile, packageBin) <<= (artifact in (Compile, packageBin), OsgiKeys.bundle).identityMap,
[warn]                                                     ^
[warn] /Users/kazuhirosera/github/oss/sbt-osgi/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala:75: method t2ToApp2 in object Scoped is deprecated: The sbt 0.10 style DSL is deprecated: '(k1, k2) map { (x, y) => ... }' should now be '{ val x = k1.value; val y = k2.value }'.
[warn] See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html
[warn]       bundleSymbolicName <<= (organization, normalizedName)(Osgi.defaultBundleSymbolicName),
[warn]                              ^
[warn] 7 warnings found
```