### PR TITLE
Properly cut the java.version for default Require-Capability header

### DIFF
--- a/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
@@ -118,10 +118,10 @@ private object Osgi {
   }
 
   def requireCapabilityTask(): String = {
-    val version = Option(System.getProperty("java.version"))
+    Option(System.getProperty("java.version"))
       .map(v => v.split("[.]", 3).take(2).mkString("."))
-      .getOrElse("1.6")
-    "osgi.ee;filter:=\"(&(osgi.ee=JavaSE)(version=%s))\"".format(version)
+      .map(version => "osgi.ee;filter:=\"(&(osgi.ee=JavaSE)(version=%s))\"".format(version))
+      .getOrElse("")
   }
 
   def headersToProperties(headers: OsgiManifestHeaders, additionalHeaders: Map[String, String]): Properties = {

--- a/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
@@ -118,7 +118,9 @@ private object Osgi {
   }
 
   def requireCapabilityTask(): String = {
-    val version = System.getProperty("java.version")
+    val version = Option(System.getProperty("java.version"))
+      .map(v => v.split("[.]", 3).take(2).mkString("."))
+      .getOrElse("1.6")
     "osgi.ee;filter:=\"(&(osgi.ee=JavaSE)(version=%s))\"".format(version)
   }
 


### PR DESCRIPTION
Without this patch, a line like this will ends up in the MANIFEST.MF

```
osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8.0_152))"
```

After the patch, the version is cut after the minor version.

```
osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
```

