### PR TITLE
Bump to a more modern version of bnd

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,11 +3,11 @@ import sbt._
 object Library {
 
   // Versions
-  val bndVersion = "2.4.0"
+  val bndVersion = "4.0.0"
   val specs2Version = "3.9.4"
 
   // Libraries
-  val bndLib = "biz.aQute.bnd" % "bndlib" % bndVersion
+  val bndLib = "biz.aQute.bnd" % "biz.aQute.bndlib" % bndVersion
   val specs2 = "org.specs2" %% "specs2-core" % specs2Version
 }
 


### PR DESCRIPTION
Hoping to avoid an NPE I saw in the scala/scala build
while working towards Java 10 support.

My NPE looked the same as the one described in
https://github.com/gradle/gradle/issues/2583, an issue
which was resolved by update bnd.

The artifact name seems to have changed in 2015
between 2.4.0 and 2.4.1

https://mvnrepository.com/artifact/biz.aQute.bnd/bndlib
https://mvnrepository.com/artifact/biz.aQute.bnd/biz.aQute.bndlib