### PR TITLE
Use all dependencies as JARs to force proper manifests (fixes #60)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html
 
 libraryDependencies ++= Dependencies.sbtOsgi
 
+version := "0.9.5-SNAPSHOT"
+
 crossSbtVersions := Seq("0.13.17", "1.1.6")
 
 scalacOptions ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,6 @@ licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html
 
 libraryDependencies ++= Dependencies.sbtOsgi
 
-version := "0.9.5-SNAPSHOT"
-
 crossSbtVersions := Seq("0.13.17", "1.1.6")
 
 scalacOptions ++= Seq(

--- a/scripted.sbt
+++ b/scripted.sbt
@@ -3,4 +3,6 @@ scriptedLaunchOpts += "-Xmx1024m"
 
 scriptedLaunchOpts += s"-Dproject.version=${version.value}"
 
+scriptedLaunchOpts += "-debug"
+
 // scriptedBufferLog := false

--- a/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
@@ -36,7 +36,7 @@ private object Osgi {
   def bundleTask(
     headers: OsgiManifestHeaders,
     additionalHeaders: Map[String, String],
-    fullClasspath: Seq[Attributed[File]],
+    fullClasspath: Seq[File],
     artifactPath: File,
     resourceDirectories: Seq[File],
     embeddedJars: Seq[File],
@@ -54,7 +54,7 @@ private object Osgi {
       validateAllPackagesDecidedAbout(internal, exported, sourceDirectories)
     }
 
-    builder.setClasspath(fullClasspath map (_.data) toArray)
+    builder.setClasspath(fullClasspath.toArray)
 
     val props = headersToProperties(headers, additionalHeaders)
     addPackageOptions(props, packageOptions)

--- a/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
@@ -44,7 +44,7 @@ object SbtOsgi extends AutoPlugin {
       bundle := Osgi.bundleTask(
         manifestHeaders.value,
         additionalHeaders.value,
-        (fullClasspath in Compile).value,
+        (dependencyClasspathAsJars in Compile).value.map(_.data) ++ (products in Compile).value,
         (artifactPath in (Compile, packageBin)).value,
         (resourceDirectories in Compile).value,
         embeddedJars.value,

--- a/src/sbt-test/sbt-osgi/test-10-multi-project-dependsOn-includePackage-versions/build.sbt
+++ b/src/sbt-test/sbt-osgi/test-10-multi-project-dependsOn-includePackage-versions/build.sbt
@@ -1,0 +1,92 @@
+import com.typesafe.sbt.osgi.SbtOsgi
+import com.typesafe.sbt.osgi.OsgiKeys
+
+
+inThisBuild(Seq(
+  organization := "com.typesafe.sbt",
+  homepage := Some(url("https://github.com/woq-blended/blended")),
+  version := "1.2.3",
+  libraryDependencies += "org.osgi" % "org.osgi.core" % "4.3.0" % "provided",
+  licenses += ("Apache 2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
+  scalaVersion := "2.12.6"
+))
+
+lazy val root = project.in(file("."))
+  .aggregate(proj1, proj2)
+
+lazy val proj1 = project.in(file("proj1"))
+  .enablePlugins(SbtOsgi)
+  .settings(
+    name := "proj1",
+    OsgiKeys.bundleSymbolicName := "proj1",
+    OsgiKeys.bundleVersion := version.value,
+    OsgiKeys.exportPackage := Seq("proj1")
+
+  )
+
+lazy val proj2 = project.in(file("proj2"))
+  .enablePlugins(SbtOsgi)
+  .dependsOn(proj1)
+  .settings(
+    name := "proj2",
+    OsgiKeys.bundleSymbolicName := "proj2",
+    OsgiKeys.bundleVersion := version.value,
+    OsgiKeys.exportPackage := Seq("proj2")
+  )
+
+
+TaskKey[Unit]("verifyBundle") := {
+  import java.io.IOException
+  import java.util.zip.ZipFile
+  import scala.io.Source
+
+  val newLine = System.getProperty("line.separator")
+
+  {
+    val file = OsgiKeys.bundle.in(proj1).value
+    val zipFile = new ZipFile(file)
+
+    // Verify manifest
+    // in essence, we make sure package proj1 gets exported with a version
+    val manifestIn = zipFile.getInputStream(zipFile.getEntry("META-INF/MANIFEST.MF"))
+    try {
+      val lines = Source.fromInputStream(manifestIn).getLines().toList
+      val allLines = lines.mkString(newLine)
+      val butWas = newLine + "But was:" + newLine + allLines
+
+      val export = Seq("Export-Package: ", "proj1;", s"""version="${version.value}"""")
+
+      if (!(lines.exists(l => export.forall(s => l.containsSlice(s))))) {
+        sys.error(s"""Expected ${export.mkString("'", "' and '", "'")} in manifest!""" + butWas)
+      }
+    } catch {
+      case e: IOException => sys.error("Expected to be able to read the manifest, but got exception!" + newLine + e)
+    } finally manifestIn.close()
+  }
+
+  {
+    val file = OsgiKeys.bundle.in(proj2).value
+    val zipFile = new ZipFile(file)
+
+    // Verify manifest
+    // in essence, we make sure, package proj2 gets imported with a proper version range
+    // in sbt-osgi <= 0.9.4, the version range was missing
+    val manifestIn = zipFile.getInputStream(zipFile.getEntry("META-INF/MANIFEST.MF"))
+    try {
+      val lines = Source.fromInputStream(manifestIn).getLines().toList
+      val allLines = lines.mkString(newLine)
+      val butWas = newLine + "But was:" + newLine + allLines
+
+      val rangeFrom = version.value.split("[.]").take(2).mkString(".")
+      val rangeTo = version.value.split("[.]").head.toInt + 1
+      val expected = Seq("Import-Package: ", s"""proj1;version="[${rangeFrom},${rangeTo})"""")
+
+      if (!(lines.exists(l => expected.forall(s => l.containsSlice(s))))) {
+        sys.error(s"""Expected ${expected.mkString("'", "' and '", "'")} in manifest!""" + butWas)
+      }
+    } catch {
+      case e: IOException => sys.error("Expected to be able to read the manifest, but got exception!" + newLine + e)
+    } finally manifestIn.close()
+  }
+
+}

--- a/src/sbt-test/sbt-osgi/test-10-multi-project-dependsOn-includePackage-versions/proj1/src/main/scala/proj1/TestTrait.scala
+++ b/src/sbt-test/sbt-osgi/test-10-multi-project-dependsOn-includePackage-versions/proj1/src/main/scala/proj1/TestTrait.scala
@@ -1,0 +1,7 @@
+package proj1
+
+trait TestTrait {
+
+  def hello(): String
+
+}

--- a/src/sbt-test/sbt-osgi/test-10-multi-project-dependsOn-includePackage-versions/proj2/src/main/scala/proj2/TestImpl.scala
+++ b/src/sbt-test/sbt-osgi/test-10-multi-project-dependsOn-includePackage-versions/proj2/src/main/scala/proj2/TestImpl.scala
@@ -1,0 +1,9 @@
+package proj2
+
+import proj1.TestTrait
+
+class TestImpl extends TestTrait {
+
+  def hello(): String = "Hello"
+
+}

--- a/src/sbt-test/sbt-osgi/test-10-multi-project-dependsOn-includePackage-versions/project/plugins.sbt
+++ b/src/sbt-test/sbt-osgi/test-10-multi-project-dependsOn-includePackage-versions/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % sys.props("project.version"))

--- a/src/sbt-test/sbt-osgi/test-10-multi-project-dependsOn-includePackage-versions/test
+++ b/src/sbt-test/sbt-osgi/test-10-multi-project-dependsOn-includePackage-versions/test
@@ -1,0 +1,1 @@
+> verifyBundle

--- a/src/sbt-test/sbt-osgi/test-10-multi-project-dependsOn-includePackage-versions/test
+++ b/src/sbt-test/sbt-osgi/test-10-multi-project-dependsOn-includePackage-versions/test
@@ -1,1 +1,2 @@
+> debug
 > verifyBundle

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
-version in ThisBuild := "0.9.4"
+version in ThisBuild := "0.9.5-SNAPSHOT"
 


### PR DESCRIPTION
This fixed #60.

After merge, a new release would be great.