### PR TITLE
Use dependencies as JARs for force proper manifests (fixes #60)

### DIFF
--- a/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
@@ -36,7 +36,7 @@ private object Osgi {
   def bundleTask(
     headers: OsgiManifestHeaders,
     additionalHeaders: Map[String, String],
-    fullClasspath: Seq[Attributed[File]],
+    fullClasspath: Seq[File],
     artifactPath: File,
     resourceDirectories: Seq[File],
     embeddedJars: Seq[File],
@@ -54,7 +54,7 @@ private object Osgi {
       validateAllPackagesDecidedAbout(internal, exported, sourceDirectories)
     }
 
-    builder.setClasspath(fullClasspath map (_.data) toArray)
+    builder.setClasspath(fullClasspath.toArray)
 
     val props = headersToProperties(headers, additionalHeaders)
     addPackageOptions(props, packageOptions)

--- a/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
@@ -44,7 +44,7 @@ object SbtOsgi extends AutoPlugin {
       bundle := Osgi.bundleTask(
         manifestHeaders.value,
         additionalHeaders.value,
-        (fullClasspath in Compile).value,
+        (dependencyClasspathAsJars in Compile).value.map(_.data) ++ (products in Compile).value,
         (artifactPath in (Compile, packageBin)).value,
         (resourceDirectories in Compile).value,
         embeddedJars.value,


### PR DESCRIPTION
This fixes #60.

This PR contains the same fixes as PR #61, but without adding the flaky integration test. #61 was reverted because of these flaky tests.
