### PR TITLE
Update Dependencies And Fix Deprecation Warnings

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,8 +3,8 @@ import sbt._
 object Library {
 
   // Versions
-  val bndVersion = "4.2.0"
-  val specs2Version = "3.9.4"
+  val bndVersion = "5.1.2"
+  val specs2Version = "4.10.3"
 
   // Libraries
   val bndLib = "biz.aQute.bnd" % "biz.aQute.bndlib" % bndVersion

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
-sbt.version=1.2.8
-
+sbt.version=1.3.13

--- a/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
@@ -28,7 +28,7 @@ import sbt._
 import sbt.Keys._
 import sbt.Package.ManifestAttributes
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.language.implicitConversions
 
 private object Osgi {
@@ -73,8 +73,8 @@ private object Osgi {
       builder.build
     }
     val log = streams.log
-    builder.getWarnings.foreach(s => log.warn(s"bnd: $s"))
-    builder.getErrors.foreach(s => log.error(s"bnd: $s"))
+    builder.getWarnings.asScala.foreach(s => log.warn(s"bnd: $s"))
+    builder.getErrors.asScala.foreach(s => log.error(s"bnd: $s"))
     jar.write(tmpArtifactPath)
     IO.move(tmpArtifactPath, artifactPath)
     artifactPath


### PR DESCRIPTION
Update the following,
* `biz.aQute.bndlib`
    * `4.2.0` -> `5.1.2`
* `specs2-core`
    * `3.9.4` -> `4.10.3`
* sbt version
    * `1.2.8` -> `1.3.13`
* Switch to use `JavaConverters` as they are not deprecated on `2.12.10`, though they are in `2.13.x`.

The impetus for this change relates to an old bug in `biz.aQute.bndlib`, which triggers a `ConcurrentModificationException` on JRE >= 15. For example, from attempting to build [scala-xml][scala-xml] with JDK 15.

```
[error] java.util.ConcurrentModificationException
[error]         at java.base/java.util.TreeMap.callMappingFunctionWithCheck(TreeMap.java:742)
[error]         at java.base/java.util.TreeMap.computeIfAbsent(TreeMap.java:596)
[error]         at aQute.bnd.osgi.Jar.putResource(Jar.java:288)
[error]         at aQute.bnd.osgi.Jar.buildFromZip(Jar.java:216)
[error]         at aQute.bnd.osgi.Jar.<init>(Jar.java:122)
[error]         at aQute.bnd.osgi.Jar.<init>(Jar.java:148)
[error]         at aQute.bnd.osgi.Analyzer.setClasspath(Analyzer.java:1597)
[error]         at com.typesafe.sbt.osgi.Osgi$.bundleTask(Osgi.scala:57)
[error]         at com.typesafe.sbt.osgi.SbtOsgi$.$anonfun$defaultOsgiSettings$1(SbtOsgi.scala:55)
[error]         at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error]         at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error]         at sbt.std.Transform$$anon$4.work(Transform.scala:67)
[error]         at sbt.Execute.$anonfun$submit$2(Execute.scala:281)
[error]         at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:19)
[error]         at sbt.Execute.work(Execute.scala:290)
[error]         at sbt.Execute.$anonfun$submit$1(Execute.scala:281)
[error]         at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error]         at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error]         at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error]         at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error]         at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
[error]         at java.base/java.lang.Thread.run(Thread.java:832)
[error] (xml / osgiBundle) java.util.ConcurrentModificationException
```

https://github.com/bndtools/bnd/issues/3903

[scala-xml]: https://github.com/scala/scala-xml "Scala XML"