### PR TITLE
Fix make sure the package does not override the bundle

### DIFF
--- a/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
@@ -45,7 +45,7 @@ object SbtOsgi extends AutoPlugin {
         manifestHeaders.value,
         additionalHeaders.value,
         (dependencyClasspathAsJars in Compile).value.map(_.data) ++ (products in Compile).value,
-        (artifactPath in (Compile, packageBin)).value,
+        (Compile / sbt.Keys.`package`).value,
         (resourceDirectories in Compile).value,
         embeddedJars.value,
         explodedJars.value,

--- a/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
@@ -45,7 +45,7 @@ object SbtOsgi extends AutoPlugin {
         manifestHeaders.value,
         additionalHeaders.value,
         (dependencyClasspathAsJars in Compile).value.map(_.data) ++ (products in Compile).value,
-        (Compile / sbt.Keys.`package`).value,
+        (artifactPath in (Compile, packageBin)).value,
         (resourceDirectories in Compile).value,
         embeddedJars.value,
         explodedJars.value,
@@ -53,6 +53,7 @@ object SbtOsgi extends AutoPlugin {
         (sourceDirectories in Compile).value,
         (packageOptions in (Compile, packageBin)).value,
         streams.value),
+      Compile / sbt.Keys.packageBin := bundle.value,
       manifestHeaders := OsgiManifestHeaders(
         bundleActivator.value,
         description.value,


### PR DESCRIPTION
On our build some bundle gets replaced by simple package due to the asynchronicity of the task. This makes sure that the package task is executed before the bundle one.