### PR TITLE
Fixed Invalid CEN extra data field on recent JVM

### DIFF
--- a/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
@@ -77,7 +77,7 @@ private object Osgi {
     builder.getWarnings.asScala.foreach(s => log.warn(s"bnd: $s"))
     builder.getErrors.asScala.foreach(s => log.error(s"bnd: $s"))
 
-    if(!useJVMJar) jar.write(tmpArtifactPath)
+    if (!useJVMJar) jar.write(tmpArtifactPath)
     else {
       val tmpArtifactDirectoryPath = file(artifactPath.absolutePath + "_tmpdir")
       IO.delete(tmpArtifactDirectoryPath)
@@ -92,7 +92,7 @@ private object Osgi {
       IO.jar(content, tmpArtifactPath, manifest)
       IO.delete(tmpArtifactDirectoryPath)
     }
-    
+
     IO.move(tmpArtifactPath, artifactPath)
     artifactPath
   }

--- a/src/main/scala/com/typesafe/sbt/osgi/OsgiKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/OsgiKeys.scala
@@ -103,6 +103,10 @@ object OsgiKeys {
     SettingKey[Boolean](prefix("FailOnUndecidedPackage"), "Fail the build if a package is neither exported or private." +
       "Without this setting such classes might be just transparently removed from the resulting artifact!")
 
+  val packageWithJVMJar: SettingKey[Boolean] =
+    SettingKey[Boolean](prefix("PackageWithJVMJar"), "Use the JVM jar tools to craft the bundle instead of the one from BND." +
+      "Without this setting the produced bundle are detected as corrupted by recent JVMs")
+
   private def prefix(key: String) = "osgi" + key
 
 }

--- a/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
@@ -52,7 +52,8 @@ object SbtOsgi extends AutoPlugin {
         failOnUndecidedPackage.value,
         (sourceDirectories in Compile).value,
         (packageOptions in (Compile, packageBin)).value,
-        streams.value),
+        streams.value,
+        packageWithJVMJar.value),
       manifestHeaders := OsgiManifestHeaders(
         bundleActivator.value,
         description.value,
@@ -84,6 +85,7 @@ object SbtOsgi extends AutoPlugin {
       requireCapability := Osgi.requireCapabilityTask(),
       additionalHeaders := Map.empty,
       embeddedJars := Nil,
-      explodedJars := Nil)
+      explodedJars := Nil,
+      packageWithJVMJar := false)
   }
 }


### PR DESCRIPTION
Jar crafted with BND raise an error when opened by the JVM jar tools:
https://bugs.openjdk.org/browse/JDK-8313765

It seems that this state of things won't be changed on the JVM side. This patch exposes an boolean settings to build the jar produced by sbt-osgi using the JVM tools instead of the one of BND. This result in bundle supported by the the build tools with no extra flags passed to the JVM.