### PR TITLE
Reduce pressure on GC by using a Traversable instead of a Seq

### DIFF
--- a/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
@@ -86,8 +86,12 @@ private object Osgi {
       val manifest = jar.getManifest
       jar.writeFolder(tmpArtifactDirectoryPath)
 
-      def content =
-        sbt.Path.contentOf(tmpArtifactDirectoryPath).filterNot { case (_, p) => p == "META-INF/MANIFEST.MF" }
+      def content = {
+        import _root_.java.nio.file.*
+        import _root_.scala.collection.JavaConverters.*
+        val path = tmpArtifactDirectoryPath.toPath
+        Files.walk(path).iterator.asScala.map(f => f.toFile -> path.relativize(f).toString).toTraversable
+      }
 
       IO.jar(content, tmpArtifactPath, manifest)
       IO.delete(tmpArtifactDirectoryPath)

--- a/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
@@ -87,8 +87,8 @@ private object Osgi {
       jar.writeFolder(tmpArtifactDirectoryPath)
 
       def content = {
-        import _root_.java.nio.file.*
-        import _root_.scala.collection.JavaConverters.*
+        import _root_.java.nio.file._
+        import _root_.scala.collection.JavaConverters._
         val path = tmpArtifactDirectoryPath.toPath
         Files.walk(path).iterator.asScala.map(f => f.toFile -> path.relativize(f).toString).filterNot { case (_, p) => p == "META-INF/MANIFEST.MF" }.toTraversable
       }

--- a/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
@@ -90,7 +90,7 @@ private object Osgi {
         import _root_.java.nio.file.*
         import _root_.scala.collection.JavaConverters.*
         val path = tmpArtifactDirectoryPath.toPath
-        Files.walk(path).iterator.asScala.map(f => f.toFile -> path.relativize(f).toString).toTraversable
+        Files.walk(path).iterator.asScala.map(f => f.toFile -> path.relativize(f).toString).filterNot { case (_, p) => p == "META-INF/MANIFEST.MF" }.toTraversable
       }
 
       IO.jar(content, tmpArtifactPath, manifest)


### PR DESCRIPTION
Listing file using contentOf primitive return a Sequence. In large projects building many concurrent bundles in parallels this put a lot of pressure on the GC. This patch uses a Traversable instead of a Seq to reduce this pressure.