### PR TITLE
Implement a cache based on hashing of the inputs of bundleTask

### DIFF
--- a/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
@@ -48,9 +48,9 @@ private object Osgi {
     cacheBundle: Boolean): Option[File] = {
 
     def fileFootprint(file: File) =
-      if(!file.exists()) Seq()
-      else if(file.isDirectory) Files.walk(file.toPath).iterator().asScala.map(f => f.toAbsolutePath.toString -> FileInfo.hash(f.toFile).hash.mkString(" ")).toSeq
-      else Seq(file.absolutePath -> FileInfo.hash(file).hash.mkString(" "))
+      if (!file.exists()) Seq()
+      else if (file.isDirectory) Files.walk(file.toPath).iterator().asScala.map(f => f.toAbsolutePath.toString -> Hash.toHex(FileInfo.hash(f.toFile).hash.toArray)).toSeq
+      else Seq(file.absolutePath -> Hash.toHex(FileInfo.hash(file).hash.toArray))
 
     def serialized =
       s"""${headers}
@@ -73,13 +73,12 @@ private object Osgi {
       val footprintValue = footprint
       val bundleCacheFootprint = file(artifactPath.absolutePath + "_footprint")
 
-      if(!bundleCacheFootprint.exists() || IO.read(bundleCacheFootprint) != footprintValue) {
+      if (!bundleCacheFootprint.exists() || IO.read(bundleCacheFootprint) != footprintValue) {
         IO.write(bundleCacheFootprint, footprintValue)
         None
-      } else if(artifactPath.exists()) Some(artifactPath) else None
+      } else if (artifactPath.exists()) Some(artifactPath) else None
     }
   }
-
   def withCache(
     headers: OsgiManifestHeaders,
     additionalHeaders: Map[String, String],

--- a/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/Osgi.scala
@@ -33,6 +33,78 @@ import scala.language.implicitConversions
 
 private object Osgi {
 
+  def cachedBundle(
+    headers: OsgiManifestHeaders,
+    additionalHeaders: Map[String, String],
+    fullClasspath: Seq[File],
+    artifactPath: File,
+    resourceDirectories: Seq[File],
+    embeddedJars: Seq[File],
+    explodedJars: Seq[File],
+    failOnUndecidedPackage: Boolean,
+    sourceDirectories: Seq[File],
+    packageOptions: scala.Seq[sbt.PackageOption],
+    useJVMJar: Boolean,
+    cacheBundle: Boolean): Option[File] = {
+
+    def footprint = {
+      val serialised =
+        s"""${headers}
+          |${additionalHeaders}
+          |${fullClasspath.map(f => FileInfo.lastModified(f).lastModified)}
+          |${artifactPath}
+          |${resourceDirectories.map(f => FileInfo.lastModified(f).lastModified)}
+          |${embeddedJars.map(f => FileInfo.lastModified(f).lastModified)}
+          |${explodedJars.map(f => FileInfo.lastModified(f).lastModified)}
+          |$failOnUndecidedPackage
+          |${sourceDirectories.map(f => FileInfo.lastModified(f).lastModified)}
+          |${packageOptions}
+          |$useJVMJar
+          |""".stripMargin
+
+      Hash.apply(serialised).mkString("")
+    }
+
+    if (!cacheBundle) None
+    else {
+      val footprintValue = footprint
+      val bundleCacheFootprint = file(artifactPath.absolutePath + "_footprint")
+
+      if(!bundleCacheFootprint.exists() || IO.read(bundleCacheFootprint) != footprintValue) {
+        IO.write(bundleCacheFootprint, footprintValue)
+        None
+      } else if(artifactPath.exists()) Some(artifactPath) else None
+    }
+  }
+
+  def withCache(
+    headers: OsgiManifestHeaders,
+    additionalHeaders: Map[String, String],
+    fullClasspath: Seq[File],
+    artifactPath: File,
+    resourceDirectories: Seq[File],
+    embeddedJars: Seq[File],
+    explodedJars: Seq[File],
+    failOnUndecidedPackage: Boolean,
+    sourceDirectories: Seq[File],
+    packageOptions: scala.Seq[sbt.PackageOption],
+    useJVMJar: Boolean,
+    cacheBundle: Boolean)(produce: => File): File =
+    cachedBundle(
+      headers,
+      additionalHeaders,
+      fullClasspath,
+      artifactPath,
+      resourceDirectories,
+      embeddedJars,
+      explodedJars,
+      failOnUndecidedPackage,
+      sourceDirectories,
+      packageOptions,
+      useJVMJar,
+      cacheBundle
+    ).getOrElse(produce)
+
   def bundleTask(
     headers: OsgiManifestHeaders,
     additionalHeaders: Map[String, String],
@@ -44,62 +116,75 @@ private object Osgi {
     failOnUndecidedPackage: Boolean,
     sourceDirectories: Seq[File],
     packageOptions: scala.Seq[sbt.PackageOption],
-    streams: TaskStreams,
-    useJVMJar: Boolean): File = {
-    val builder = new Builder
+    useJVMJar: Boolean,
+    cacheBundle: Boolean,
+    streams: TaskStreams): File =
+    withCache(headers,
+      additionalHeaders,
+      fullClasspath,
+      artifactPath,
+      resourceDirectories,
+      embeddedJars,
+      explodedJars,
+      failOnUndecidedPackage,
+      sourceDirectories,
+      packageOptions,
+      useJVMJar,
+      cacheBundle) {
+        val builder = new Builder
 
-    if (failOnUndecidedPackage) {
-      streams.log.info("Validating all packages are set private or exported for OSGi explicitly...")
-      val internal = headers.privatePackage
-      val exported = headers.exportPackage
-      validateAllPackagesDecidedAbout(internal, exported, sourceDirectories)
+        if (failOnUndecidedPackage) {
+          streams.log.info("Validating all packages are set private or exported for OSGi explicitly...")
+          val internal = headers.privatePackage
+          val exported = headers.exportPackage
+          validateAllPackagesDecidedAbout(internal, exported, sourceDirectories)
+        }
+
+        builder.setClasspath(fullClasspath.toArray)
+
+        val props = headersToProperties(headers, additionalHeaders)
+        addPackageOptions(props, packageOptions)
+        builder.setProperties(props)
+
+        includeResourceProperty(resourceDirectories.filter(_.exists), embeddedJars, explodedJars) foreach (dirs =>
+          builder.setProperty(INCLUDERESOURCE, dirs))
+        bundleClasspathProperty(embeddedJars) foreach (jars =>
+          builder.setProperty(BUNDLE_CLASSPATH, jars))
+        // Write to a temporary file to prevent trying to simultaneously read from and write to the
+        // same jar file in exportJars mode (which causes a NullPointerException).
+        val tmpArtifactPath = file(artifactPath.absolutePath + ".tmp")
+        // builder.build is not thread-safe because it uses a static SimpleDateFormat.  This ensures
+        // that all calls to builder.build are serialized.
+        val jar = synchronized {
+          builder.build
+        }
+        val log = streams.log
+        builder.getWarnings.asScala.foreach(s => log.warn(s"bnd: $s"))
+        builder.getErrors.asScala.foreach(s => log.error(s"bnd: $s"))
+
+        if (!useJVMJar) jar.write(tmpArtifactPath)
+        else {
+          val tmpArtifactDirectoryPath = file(artifactPath.absolutePath + "_tmpdir")
+          IO.delete(tmpArtifactDirectoryPath)
+          tmpArtifactDirectoryPath.mkdirs()
+
+          val manifest = jar.getManifest
+          jar.writeFolder(tmpArtifactDirectoryPath)
+
+          def content = {
+            import _root_.java.nio.file._
+            import _root_.scala.collection.JavaConverters._
+            val path = tmpArtifactDirectoryPath.toPath
+            Files.walk(path).iterator.asScala.map(f => f.toFile -> path.relativize(f).toString).filterNot { case (_, p) => p == "META-INF/MANIFEST.MF" }.toTraversable
+          }
+
+          IO.jar(content, tmpArtifactPath, manifest)
+          IO.delete(tmpArtifactDirectoryPath)
+        }
+
+        IO.move(tmpArtifactPath, artifactPath)
+        artifactPath
     }
-
-    builder.setClasspath(fullClasspath.toArray)
-
-    val props = headersToProperties(headers, additionalHeaders)
-    addPackageOptions(props, packageOptions)
-    builder.setProperties(props)
-
-    includeResourceProperty(resourceDirectories.filter(_.exists), embeddedJars, explodedJars) foreach (dirs =>
-      builder.setProperty(INCLUDERESOURCE, dirs))
-    bundleClasspathProperty(embeddedJars) foreach (jars =>
-      builder.setProperty(BUNDLE_CLASSPATH, jars))
-    // Write to a temporary file to prevent trying to simultaneously read from and write to the
-    // same jar file in exportJars mode (which causes a NullPointerException).
-    val tmpArtifactPath = file(artifactPath.absolutePath + ".tmp")
-    // builder.build is not thread-safe because it uses a static SimpleDateFormat.  This ensures
-    // that all calls to builder.build are serialized.
-    val jar = synchronized {
-      builder.build
-    }
-    val log = streams.log
-    builder.getWarnings.asScala.foreach(s => log.warn(s"bnd: $s"))
-    builder.getErrors.asScala.foreach(s => log.error(s"bnd: $s"))
-
-    if (!useJVMJar) jar.write(tmpArtifactPath)
-    else {
-      val tmpArtifactDirectoryPath = file(artifactPath.absolutePath + "_tmpdir")
-      IO.delete(tmpArtifactDirectoryPath)
-      tmpArtifactDirectoryPath.mkdirs()
-
-      val manifest = jar.getManifest
-      jar.writeFolder(tmpArtifactDirectoryPath)
-
-      def content = {
-        import _root_.java.nio.file._
-        import _root_.scala.collection.JavaConverters._
-        val path = tmpArtifactDirectoryPath.toPath
-        Files.walk(path).iterator.asScala.map(f => f.toFile -> path.relativize(f).toString).filterNot { case (_, p) => p == "META-INF/MANIFEST.MF" }.toTraversable
-      }
-
-      IO.jar(content, tmpArtifactPath, manifest)
-      IO.delete(tmpArtifactDirectoryPath)
-    }
-
-    IO.move(tmpArtifactPath, artifactPath)
-    artifactPath
-  }
 
   private def addPackageOptions(props: Properties, packageOptions: Seq[PackageOption]) = {
     packageOptions

--- a/src/main/scala/com/typesafe/sbt/osgi/OsgiKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/OsgiKeys.scala
@@ -107,10 +107,17 @@ object OsgiKeys {
     SettingKey[Boolean](prefix("PackageWithJVMJar"), "Use the JVM jar tools to craft the bundle instead of the one from BND." +
       "Without this setting the produced bundle are detected as corrupted by recent JVMs")
 
-  val cacheBundle: SettingKey[Boolean] =
-    SettingKey[Boolean](prefix("CacheBundle"), "Do not build a new bundle if a bundle already exists and has been crafted from identical inputs")
+  val cacheStrategy: SettingKey[Option[CacheStrategy]] =
+    SettingKey[Option[CacheStrategy]](prefix("CacheBundle"), "Do not build a new bundle if a bundle already exists and has been crafted from identical inputs")
 
 
   private def prefix(key: String) = "osgi" + key
 
+
+  sealed trait CacheStrategy
+
+  object CacheStrategy {
+    object Hash extends CacheStrategy
+    object LastModified extends CacheStrategy
+  }
 }

--- a/src/main/scala/com/typesafe/sbt/osgi/OsgiKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/OsgiKeys.scala
@@ -107,6 +107,10 @@ object OsgiKeys {
     SettingKey[Boolean](prefix("PackageWithJVMJar"), "Use the JVM jar tools to craft the bundle instead of the one from BND." +
       "Without this setting the produced bundle are detected as corrupted by recent JVMs")
 
+  val cacheBundle: SettingKey[Boolean] =
+    SettingKey[Boolean](prefix("CacheBundle"), "Do not build a new bundle if a bundle already exists and has been crafted from identical inputs")
+
+
   private def prefix(key: String) = "osgi" + key
 
 }

--- a/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
@@ -53,7 +53,7 @@ object SbtOsgi extends AutoPlugin {
         (sourceDirectories in Compile).value,
         (packageOptions in (Compile, packageBin)).value,
         packageWithJVMJar.value,
-        cacheBundle.value,
+        cacheStrategy.value,
         streams.value),
       Compile / sbt.Keys.packageBin := bundle.value,
       manifestHeaders := OsgiManifestHeaders(
@@ -89,6 +89,6 @@ object SbtOsgi extends AutoPlugin {
       embeddedJars := Nil,
       explodedJars := Nil,
       packageWithJVMJar := false,
-      cacheBundle := false)
+      cacheStrategy := None)
   }
 }

--- a/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/SbtOsgi.scala
@@ -52,8 +52,9 @@ object SbtOsgi extends AutoPlugin {
         failOnUndecidedPackage.value,
         (sourceDirectories in Compile).value,
         (packageOptions in (Compile, packageBin)).value,
-        streams.value,
-        packageWithJVMJar.value),
+        packageWithJVMJar.value,
+        cacheBundle.value,
+        streams.value),
       Compile / sbt.Keys.packageBin := bundle.value,
       manifestHeaders := OsgiManifestHeaders(
         bundleActivator.value,
@@ -87,6 +88,7 @@ object SbtOsgi extends AutoPlugin {
       additionalHeaders := Map.empty,
       embeddedJars := Nil,
       explodedJars := Nil,
-      packageWithJVMJar := false)
+      packageWithJVMJar := false,
+      cacheBundle := false)
   }
 }


### PR DESCRIPTION
In case no file and no settings have been modified and the bundle exist do no generate it.

Add an opt-in key to avoid breaking things...

It solves https://github.com/sbt/sbt-osgi/issues/27