### PR TITLE
Pin Scala updates for scala-steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.pin = [
+  { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." }
+]


### PR DESCRIPTION
So that Scala Steward doesn't try and update Scala major/minor versions