### PR TITLE
Rename com.typesafe.sbt package to com.github.sbt

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ enablePlugins(SbtOsgi)
 Example `<PROJECT_ROOT>/project/Build.scala`:
 ```scala
 import sbt._
-import com.typesafe.sbt.SbtOsgi.autoImport._  // The autoImport object contains everything which would normally be
-                                              // imported automatically in '*.sbt' project definition files.
+import com.github.sbt.SbtOsgi.autoImport._  // The autoImport object contains everything which would normally be
+                                            // imported automatically in '*.sbt' project definition files.
 
 object Build extends sbt.Build {
 
@@ -125,9 +125,9 @@ libraryDependencies += "org.osgi" % "org.osgi.core" % "4.3.0" % "provided"
 
 osgiSettings
 
-OsgiKeys.exportPackage := Seq("com.typesafe.sbt.osgidemo")
+OsgiKeys.exportPackage := Seq("com.github.sbt.osgidemo")
 
-OsgiKeys.bundleActivator := Option("com.typesafe.sbt.osgidemo.internal.Activator")
+OsgiKeys.bundleActivator := Option("com.github.sbt.osgidemo.internal.Activator")
 ```
 
 Contribution policy

--- a/src/main/scala/com/github/sbt/osgi/Osgi.scala
+++ b/src/main/scala/com/github/sbt/osgi/Osgi.scala
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package com.typesafe.sbt.osgi
+package com.github.sbt.osgi
 
 import java.nio.file.{ FileVisitOption, Files, Path }
 
 import aQute.bnd.osgi.Builder
 import aQute.bnd.osgi.Constants._
-import com.typesafe.sbt.osgi.OsgiKeys.CacheStrategy
+import com.github.sbt.osgi.OsgiKeys.CacheStrategy
 import java.util.Properties
 import java.util.function.Predicate
 import java.util.stream.Collectors

--- a/src/main/scala/com/github/sbt/osgi/OsgiKeys.scala
+++ b/src/main/scala/com/github/sbt/osgi/OsgiKeys.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.typesafe.sbt.osgi
+package com.github.sbt.osgi
 
 import sbt._
 

--- a/src/main/scala/com/github/sbt/osgi/OsgiManifestHeaders.scala
+++ b/src/main/scala/com/github/sbt/osgi/OsgiManifestHeaders.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.typesafe.sbt.osgi
+package com.github.sbt.osgi
 
 import sbt.URL
 

--- a/src/main/scala/com/github/sbt/osgi/SbtOsgi.scala
+++ b/src/main/scala/com/github/sbt/osgi/SbtOsgi.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.typesafe.sbt.osgi
+package com.github.sbt.osgi
 
 import sbt._
 import sbt.Keys._
@@ -31,9 +31,9 @@ object SbtOsgi extends AutoPlugin {
   override lazy val globalSettings: Seq[Def.Setting[_]] = defaultGlobalSettings
 
   object autoImport {
-    type OsgiManifestHeaders = com.typesafe.sbt.osgi.OsgiManifestHeaders
+    type OsgiManifestHeaders = com.github.sbt.osgi.OsgiManifestHeaders
 
-    val OsgiKeys = com.typesafe.sbt.osgi.OsgiKeys
+    val OsgiKeys = com.github.sbt.osgi.OsgiKeys
 
     lazy val osgiSettings: Seq[Setting[_]] = Seq(
       Compile / packageBin / packagedArtifact := Scoped

--- a/src/main/scala/com/typesafe/sbt/osgi/package.scala
+++ b/src/main/scala/com/typesafe/sbt/osgi/package.scala
@@ -1,0 +1,12 @@
+package com.typesafe.sbt
+
+package object osgi {
+  @deprecated("Use com.github.sbt.osgi.OsgiKeys instead", "0.10.0")
+  val OsgiKeys = com.github.sbt.osgi.OsgiKeys
+  @deprecated("Use com.github.sbt.osgi.OsgiKeys instead", "0.10.0")
+  type OsgiKeys = com.github.sbt.osgi.OsgiKeys
+  @deprecated("Use com.github.sbt.osgi.OsgiManifestHeaders instead", "0.10.0")
+  type OsgiManifestHeaders = com.github.sbt.osgi.OsgiManifestHeaders
+  @deprecated("Use com.github.sbt.osgi.SbtOsgi instead", "0.10.0")
+  val SbtOsgi = com.github.sbt.osgi.SbtOsgi
+}

--- a/src/sbt-test/sbt-osgi/test-10-multi-project-dependsOn-includePackage-versions/build.sbt
+++ b/src/sbt-test/sbt-osgi/test-10-multi-project-dependsOn-includePackage-versions/build.sbt
@@ -1,5 +1,5 @@
-import com.typesafe.sbt.osgi.SbtOsgi
-import com.typesafe.sbt.osgi.OsgiKeys
+import com.github.sbt.osgi.SbtOsgi
+import com.github.sbt.osgi.OsgiKeys
 
 inThisBuild(
   Seq(

--- a/src/test/scala/com/github/sbt/osgi/OsgiSpec.scala
+++ b/src/test/scala/com/github/sbt/osgi/OsgiSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.typesafe.sbt.osgi
+package com.github.sbt.osgi
 
 import aQute.bnd.osgi.Constants._
 import java.io.File


### PR DESCRIPTION
Renames `com.typesafe.sbt` the package to `com.github.sbt` as well as providing a deprecated alias for the `com.typesafe.sbt`.

The intention is to release `0.10.0` containing the proper fixed package.