### PR TITLE
Bundle manifest in right way

### DIFF
--- a/src/main/scala/com/github/sbt/osgi/SbtOsgi.scala
+++ b/src/main/scala/com/github/sbt/osgi/SbtOsgi.scala
@@ -17,6 +17,7 @@
 package com.github.sbt.osgi
 
 import sbt._
+import sbt.Classpaths.concat
 import sbt.Keys._
 import sbt.plugins.JvmPlugin
 
@@ -46,10 +47,11 @@ object SbtOsgi extends AutoPlugin {
     import OsgiKeys._
     Seq(
       (Compile / exportJars) := false,
+      (Compile / fullClasspath) := concat(Compile / exportedProducts, Compile / dependencyClasspathAsJars).value,
       bundle := Osgi.bundleTask(
         manifestHeaders.value,
         additionalHeaders.value,
-        (Compile / fullClasspath).value.map(_.data) ++ (Compile / internalDependencyAsJars).value.map(_.data),
+        (Compile / fullClasspath).value.map(_.data),
         (Compile / packageBin / artifactPath).value,
         (Compile / resourceDirectories).value,
         embeddedJars.value,

--- a/src/main/scala/com/github/sbt/osgi/SbtOsgi.scala
+++ b/src/main/scala/com/github/sbt/osgi/SbtOsgi.scala
@@ -45,10 +45,11 @@ object SbtOsgi extends AutoPlugin {
   lazy val defaultOsgiSettings: Seq[Setting[_]] = {
     import OsgiKeys._
     Seq(
+      (Compile / exportJars) := false,
       bundle := Osgi.bundleTask(
         manifestHeaders.value,
         additionalHeaders.value,
-        (Compile / dependencyClasspathAsJars).value.map(_.data) ++ (Compile / products).value,
+        (Compile / fullClasspath).value.map(_.data) ++ (Compile / internalDependencyAsJars).value.map(_.data),
         (Compile / packageBin / artifactPath).value,
         (Compile / resourceDirectories).value,
         embeddedJars.value,
@@ -78,7 +79,6 @@ object SbtOsgi extends AutoPlugin {
         requireBundle.value,
         requireCapability.value
       ),
-      Compile / sbt.Keys.packageBin := bundle.value,
       bundleSymbolicName := Osgi.defaultBundleSymbolicName(organization.value, normalizedName.value),
       privatePackage := bundleSymbolicName(name => List(name + ".*")).value,
       bundleVersion := version.value

--- a/src/sbt-test/sbt-osgi/test-00-defaults/build.sbt
+++ b/src/sbt-test/sbt-osgi/test-00-defaults/build.sbt
@@ -8,6 +8,8 @@ version := "1.2.3"
 
 libraryDependencies += "org.osgi" % "org.osgi.core" % "4.3.0" % "provided"
 
+(Compile / packageBin) := OsgiKeys.bundle.value
+
 osgiSettings
 
 TaskKey[Unit]("verifyBundleActivator") := {

--- a/src/sbt-test/sbt-osgi/test-10-multi-project-dependsOn-includePackage-versions/build.sbt
+++ b/src/sbt-test/sbt-osgi/test-10-multi-project-dependsOn-includePackage-versions/build.sbt
@@ -22,7 +22,8 @@ lazy val proj1 = project
     name := "proj1",
     OsgiKeys.bundleSymbolicName := "proj1",
     OsgiKeys.bundleVersion := version.value,
-    OsgiKeys.exportPackage := Seq("proj1")
+    OsgiKeys.exportPackage := Seq("proj1"),
+    (Compile / packageBin) := OsgiKeys.bundle.value
   )
 
 lazy val proj2 = project
@@ -33,7 +34,8 @@ lazy val proj2 = project
     name := "proj2",
     OsgiKeys.bundleSymbolicName := "proj2",
     OsgiKeys.bundleVersion := version.value,
-    OsgiKeys.exportPackage := Seq("proj2")
+    OsgiKeys.exportPackage := Seq("proj2"),
+    (Compile / packageBin) := OsgiKeys.bundle.value
   )
 
 TaskKey[Unit]("verifyBundle") := {


### PR DESCRIPTION
## Motivation
Rollback to use (Compile / fullClasspath), import manifest via `(Compile / internalDependencyAsJars)`

## Verifed

[info] [error] java.lang.RuntimeException: Expected 'Import-Package: ' and 'proj1;version="[1.2,2)"' in manifest!
[info] [error] Import-Package: proj1,scala.reflect;version="[2.12,3)"

## Conclusion

Only `test-10-multi-project-dependsOn-includePackage-versions` will complain, We need additional submissions to fix the packaging of this information. It seems that we have added an additional package name `scala.reflect`.

Waiting feedback from @mdedetrich 


