### PR TITLE
Avoid deprecated java.net.URL constructor

### DIFF
--- a/src/main/scala-3/com/github/sbt/osgi/PluginCompat.scala
+++ b/src/main/scala-3/com/github/sbt/osgi/PluginCompat.scala
@@ -6,7 +6,7 @@ import sbt.librarymanagement.License
 
 private[osgi] object PluginCompat {
   def licenses(v: Seq[License]): Seq[(String, URL)] =
-    v.map(l => l.spdxId -> new URL(l.uri.toString))
+    v.map(l => l.spdxId -> l.uri.toURL)
   def apiUrl(v: Option[URI]): Option[URL] =
     v.map(u => new URI(u.toString).toURL)
   type ManifestAttributes = sbt.PackageOption.ManifestAttributes


### PR DESCRIPTION
- https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/URL.html#%3Cinit%3E(java.lang.String)
- https://bugs.openjdk.org/browse/JDK-8295949